### PR TITLE
Added some feature from the "original" android library

### DIFF
--- a/PlacesBarExamples/PlacesBarExamples/PlacesBarExamplesPage.xaml
+++ b/PlacesBarExamples/PlacesBarExamples/PlacesBarExamplesPage.xaml
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
 		xmlns:local="clr-namespace:PlacesBarExamples" x:Class="PlacesBarExamples.PlacesBarExamplesPage"
-		xmlns:custom="clr-namespace:DurianCode.PlacesSearchBar;assembly=PlacesSearchBar">
+		xmlns:custom="clr-namespace:DurianCode.PlacesSearchBar;assembly=PlacesSearchBar"
+		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+		mc:Ignorable="d">
 	<ContentPage.Padding>
 		<OnPlatform x:TypeArguments="Thickness" iOS="0, 20, 0, 0" Android="0" />
 	</ContentPage.Padding>
@@ -15,7 +18,7 @@
 				AbsoluteLayout.LayoutBounds="0, 0, 1, 1" AbsoluteLayout.LayoutFlags="SizeProportional" >
 				<ListView.ItemTemplate>
 					<DataTemplate>
-						<TextCell Text="{Binding Description}" Detail="{Binding Place_ID}" />
+						<TextCell d:DataContext="{d:DesignInstance custom:AutoCompletePrediction}" Text="{Binding MainText}" Detail="{Binding SecondaryText}" />
 					</DataTemplate>
 				</ListView.ItemTemplate>
 			</ListView>

--- a/PlacesSearchBar/AddressComponent.cs
+++ b/PlacesSearchBar/AddressComponent.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace DurianCode.PlacesSearchBar
+{
+	public class AddressComponent
+	{
+		public string LongName { get; }
+		public string ShortName { get; }
+
+		public IReadOnlyCollection<string> Types { get; }
+
+		public AddressComponent(string longcomp, string shortcomp, IEnumerable<string> types)
+		{
+			LongName  = longcomp;
+			ShortName = shortcomp;
+			Types     = types.ToList().AsReadOnly();
+		}
+
+		public static AddressComponent FromJSON(JObject json)
+		{
+			return new AddressComponent(json["long_name"].Value<string>(), json["short_name"].Value<string>(), json["types"].Value<JArray>().Select(p => p.Value<string>()));
+		}
+
+		public override string ToString() => string.IsNullOrWhiteSpace(LongName) ? (ShortName ?? string.Empty) : LongName;
+	}
+}

--- a/PlacesSearchBar/AutoCompletePrediction.cs
+++ b/PlacesSearchBar/AutoCompletePrediction.cs
@@ -25,6 +25,7 @@
 // THE SOFTWARE.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DurianCode.PlacesSearchBar
 {
@@ -37,29 +38,51 @@ namespace DurianCode.PlacesSearchBar
 		/// Gets or sets the description.
 		/// </summary>
 		/// <value>The description.</value>
-		[JsonProperty("description")]
 		public string Description { get; set; }
 
 		/// <summary>
 		/// Gets or sets the identifier.
 		/// </summary>
 		/// <value>The identifier.</value>
-		[JsonProperty("id")]
 		public string ID { get; set; }
 
 		/// <summary>
 		/// Gets or sets the place identifier.
 		/// </summary>
 		/// <value>The place identifier.</value>
-		[JsonProperty("place_id")]
 		public string Place_ID { get; set; }
 
 		/// <summary>
 		/// Gets or sets the reference.
 		/// </summary>
 		/// <value>The reference.</value>
-		[JsonProperty("reference")]
 		public string Reference { get; set; }
+
+		/// <summary>
+		/// Gets the main text for UI display
+		/// </summary>
+		/// <value>The main text.</value>
+		public string MainText { get; set; }
+
+		/// <summary>
+		/// Gets the secondary text for UI display
+		/// </summary>
+		/// <value>The secondary text.</value>
+		public string SecondaryText { get; set; }
+
+		public static AutoCompletePrediction FromJson(JObject json)
+		{
+			var r = new AutoCompletePrediction();
+
+			r.Description   = json["description"].Value<string>();
+			r.ID            = json["id"].Value<string>();
+			r.Place_ID      = json["place_id"].Value<string>();
+			r.Reference     = json["reference"].Value<string>();
+			r.MainText      = json["structured_formatting"]["main_text"].Value<string>();
+			r.SecondaryText = json["structured_formatting"]["secondary_text"].Value<string>();
+
+			return r;
+		}
 	}
 
 }

--- a/PlacesSearchBar/AutoCompletePrediction.cs
+++ b/PlacesSearchBar/AutoCompletePrediction.cs
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -70,16 +72,33 @@ namespace DurianCode.PlacesSearchBar
 		/// <value>The secondary text.</value>
 		public string SecondaryText { get; set; }
 
+		/// <summary>
+		/// Gets the individual terms of this prediction
+		/// </summary>
+		/// <value>The terms.</value>
+		public List<string> Terms { get; set; }
+
+		/// <summary>
+		/// Gets the types of this prediction
+		/// see https://developers.google.com/places/web-service/supported_types
+		/// </summary>
+		/// <value>The types of the prediction.</value>
+		public List<string> Types { get; set; }
+
 		public static AutoCompletePrediction FromJson(JObject json)
 		{
-			var r = new AutoCompletePrediction();
+			var r = new AutoCompletePrediction
+			{
+				Description   = json["description"].Value<string>(),
+				ID            = json["id"].Value<string>(),
+				Place_ID      = json["place_id"].Value<string>(),
+				Reference     = json["reference"].Value<string>(),
+				MainText      = json["structured_formatting"]["main_text"].Value<string>(),
+				SecondaryText = json["structured_formatting"]["secondary_text"].Value<string>(),
+				Terms         = json["terms"].Value<JArray>().Select(p => p["value"].Value<string>()).ToList(),
+				Types         = json["types"].Value<JArray>().Select(p => p.Value<string>()).ToList()
+			};
 
-			r.Description   = json["description"].Value<string>();
-			r.ID            = json["id"].Value<string>();
-			r.Place_ID      = json["place_id"].Value<string>();
-			r.Reference     = json["reference"].Value<string>();
-			r.MainText      = json["structured_formatting"]["main_text"].Value<string>();
-			r.SecondaryText = json["structured_formatting"]["secondary_text"].Value<string>();
 
 			return r;
 		}

--- a/PlacesSearchBar/AutoCompletePrediction.cs
+++ b/PlacesSearchBar/AutoCompletePrediction.cs
@@ -26,7 +26,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace DurianCode.PlacesSearchBar
@@ -98,7 +97,6 @@ namespace DurianCode.PlacesSearchBar
 				Terms         = json["terms"].Value<JArray>().Select(p => p["value"].Value<string>()).ToList(),
 				Types         = json["types"].Value<JArray>().Select(p => p.Value<string>()).ToList()
 			};
-
 
 			return r;
 		}

--- a/PlacesSearchBar/AutoCompleteResult.cs
+++ b/PlacesSearchBar/AutoCompleteResult.cs
@@ -27,6 +27,7 @@
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DurianCode.PlacesSearchBar
 {
@@ -49,6 +50,21 @@ namespace DurianCode.PlacesSearchBar
 		/// <value>The auto complete places.</value>
 		[JsonProperty("predictions")]
 		public List<AutoCompletePrediction> AutoCompletePlaces { get; set; }
-	}
+
+		public static AutoCompleteResult FromJson(JObject result)
+		{
+			var r = new AutoCompleteResult();
+
+			r.Status = result["status"].Value<string>();
+
+			r.AutoCompletePlaces = new List<AutoCompletePrediction>();
+			foreach (var obj in result["predictions"].Value<JArray>())
+			{
+				r.AutoCompletePlaces.Add(AutoCompletePrediction.FromJson(obj.Value<JObject>()));
+			}
+
+			return r;
+		}
+    }
 
 }

--- a/PlacesSearchBar/GoogleAPILanguage.cs
+++ b/PlacesSearchBar/GoogleAPILanguage.cs
@@ -1,0 +1,185 @@
+﻿namespace DurianCode.PlacesSearchBar
+{
+	public enum GoogleAPILanguage
+	{
+		Unset,
+
+		Afrikaans,
+		Albanian,
+		Amharic,
+		Arabic,
+		Armenian,
+		Azerbaijani,
+		Basque,
+		Belarusian,
+		Bengali,
+		Bosnian,
+		Bulgarian,
+		Burmese,
+		Catalan,
+		Chinese,
+		ChineseSimplified,
+		ChineseHongKong,
+		ChineseTraditional,
+		Croatian,
+		Czech,
+		Danish,
+		Dutch,
+		English,
+		EnglishAustralian,
+		EnglishGreatBritain,
+		Estonian,
+		Farsi,
+		Finnish,
+		Filipino,
+		French,
+		FrenchCanada,
+		Galician,
+		Georgian,
+		German,
+		Greek,
+		Gujarati,
+		Hebrew,
+		Hindi,
+		Hungarian,
+		Icelandic,
+		Indonesian,
+		Italian,
+		Japanese,
+		Kannada,
+		Kazakh,
+		Khmer,
+		Korean,
+		Kyrgyz,
+		Lao,
+		Latvian,
+		Lithuanian,
+		Macedonian,
+		Malay,
+		Malayalam,
+		Marathi,
+		Mongolian,
+		Nepali,
+		Norwegian,
+		Polish,
+		Portuguese,
+		PortugueseBrazil,
+		PortuguesePortugal,
+		Punjabi,
+		Romanian,
+		Russian,
+		Serbian,
+		Sinhalese,
+		Slovak,
+		Slovenian,
+		Spanish,
+		SpanishLatinAmerica,
+		Swahili,
+		Swedish,
+		Tamil,
+		Telugu,
+		Thai,
+		Turkish,
+		Ukrainian,
+		Urdu,
+		Uzbek,
+		Vietnamese,
+		Zulu,
+	}
+
+	class GoogleAPILanguageHelper
+	{
+		public static string ToAPIString(GoogleAPILanguage lng)
+		{
+			// https://developers.google.com/maps/faq#languagesupport
+
+			switch (lng)
+			{
+				case GoogleAPILanguage.Afrikaans:               return "af";
+				case GoogleAPILanguage.Albanian:                return "sq";
+				case GoogleAPILanguage.Amharic:                 return "am";
+				case GoogleAPILanguage.Arabic:                  return "ar";
+				case GoogleAPILanguage.Armenian:                return "ar";
+				case GoogleAPILanguage.Azerbaijani:             return "az";
+				case GoogleAPILanguage.Basque:                  return "eu";
+				case GoogleAPILanguage.Belarusian:              return "be";
+				case GoogleAPILanguage.Bengali:                 return "bn";
+				case GoogleAPILanguage.Bosnian:                 return "bs";
+				case GoogleAPILanguage.Bulgarian:               return "bg";
+				case GoogleAPILanguage.Burmese:                 return "my";
+				case GoogleAPILanguage.Catalan:                 return "ca";
+				case GoogleAPILanguage.Chinese:                 return "zh";
+				case GoogleAPILanguage.ChineseSimplified:       return "zh-CN";
+				case GoogleAPILanguage.ChineseHongKong:         return "zh-HK";
+				case GoogleAPILanguage.ChineseTraditional:      return "zh-TW";
+				case GoogleAPILanguage.Croatian:                return "hr";
+				case GoogleAPILanguage.Czech:                   return "cs";
+				case GoogleAPILanguage.Danish:                  return "da";
+				case GoogleAPILanguage.Dutch:                   return "nl";
+				case GoogleAPILanguage.English:                 return "en";
+				case GoogleAPILanguage.EnglishAustralian:       return "en-AU";
+				case GoogleAPILanguage.EnglishGreatBritain:     return "en-GB";
+				case GoogleAPILanguage.Estonian:                return "et";
+				case GoogleAPILanguage.Farsi:                   return "fa";
+				case GoogleAPILanguage.Finnish:                 return "fi";
+				case GoogleAPILanguage.Filipino:                return "fil";
+				case GoogleAPILanguage.French:                  return "fr";
+				case GoogleAPILanguage.FrenchCanada:            return "fr-CA";
+				case GoogleAPILanguage.Galician:                return "gl";
+				case GoogleAPILanguage.Georgian:                return "ka";
+				case GoogleAPILanguage.German:                  return "de";
+				case GoogleAPILanguage.Greek:                   return "el";
+				case GoogleAPILanguage.Gujarati:                return "gu";
+				case GoogleAPILanguage.Hebrew:                  return "iw";
+				case GoogleAPILanguage.Hindi:                   return "hi";
+				case GoogleAPILanguage.Hungarian:               return "hu";
+				case GoogleAPILanguage.Icelandic:               return "is";
+				case GoogleAPILanguage.Indonesian:              return "id";
+				case GoogleAPILanguage.Italian:                 return "it";
+				case GoogleAPILanguage.Japanese:                return "ja";
+				case GoogleAPILanguage.Kannada:                 return "kn";
+				case GoogleAPILanguage.Kazakh:                  return "kk";
+				case GoogleAPILanguage.Khmer:                   return "km";
+				case GoogleAPILanguage.Korean:                  return "ko";
+				case GoogleAPILanguage.Kyrgyz:                  return "ky";
+				case GoogleAPILanguage.Lao:                     return "lo";
+				case GoogleAPILanguage.Latvian:                 return "lv";
+				case GoogleAPILanguage.Lithuanian:              return "lt";
+				case GoogleAPILanguage.Macedonian:              return "mk";
+				case GoogleAPILanguage.Malay:                   return "ms";
+				case GoogleAPILanguage.Malayalam:               return "ml";
+				case GoogleAPILanguage.Marathi:                 return "mr";
+				case GoogleAPILanguage.Mongolian:               return "mn";
+				case GoogleAPILanguage.Nepali:                  return "ne";
+				case GoogleAPILanguage.Norwegian:               return "no";
+				case GoogleAPILanguage.Polish:                  return "pl";
+				case GoogleAPILanguage.Portuguese:              return "pt";
+				case GoogleAPILanguage.PortugueseBrazil:        return "pt-BR";
+				case GoogleAPILanguage.PortuguesePortugal:      return "pt-PT";
+				case GoogleAPILanguage.Punjabi:                 return "pa";
+				case GoogleAPILanguage.Romanian:                return "ro";
+				case GoogleAPILanguage.Russian:                 return "ru";
+				case GoogleAPILanguage.Serbian:                 return "sr";
+				case GoogleAPILanguage.Sinhalese:               return "si";
+				case GoogleAPILanguage.Slovak:                  return "sk";
+				case GoogleAPILanguage.Slovenian:               return "sl";
+				case GoogleAPILanguage.Spanish:                 return "es";
+				case GoogleAPILanguage.SpanishLatinAmerica:     return "es-419";
+				case GoogleAPILanguage.Swahili:                 return "sw";
+				case GoogleAPILanguage.Swedish:                 return "sv";
+				case GoogleAPILanguage.Tamil:                   return "ta";
+				case GoogleAPILanguage.Telugu:                  return "te";
+				case GoogleAPILanguage.Thai:                    return "th";
+				case GoogleAPILanguage.Turkish:                 return "tr";
+				case GoogleAPILanguage.Ukrainian:               return "uk";
+				case GoogleAPILanguage.Urdu:                    return "ur";
+				case GoogleAPILanguage.Uzbek:                   return "uz";
+				case GoogleAPILanguage.Vietnamese:              return "vi";
+				case GoogleAPILanguage.Zulu:                    return "zu";
+					
+				case GoogleAPILanguage.Unset                    return "zu";
+				default:                                        return "";
+			}
+		}
+	}
+}

--- a/PlacesSearchBar/GoogleAPILanguage.cs
+++ b/PlacesSearchBar/GoogleAPILanguage.cs
@@ -177,7 +177,7 @@
 				case GoogleAPILanguage.Vietnamese:              return "vi";
 				case GoogleAPILanguage.Zulu:                    return "zu";
 					
-				case GoogleAPILanguage.Unset                    return "zu";
+				case GoogleAPILanguage.Unset:                   return "zu";
 				default:                                        return "";
 			}
 		}

--- a/PlacesSearchBar/Place.cs
+++ b/PlacesSearchBar/Place.cs
@@ -37,6 +37,24 @@ namespace DurianCode.PlacesSearchBar
 	public class Place
 	{
 		/// <summary>
+		/// Gets or sets the identifier (can be NULL).
+		/// </summary>
+		/// <value>The identifier.</value>
+		public string ID { get; set; }
+
+		/// <summary>
+		/// Gets or sets the place identifier.
+		/// </summary>
+		/// <value>The place identifier.</value>
+		public string Place_ID { get; set; }
+
+		/// <summary>
+		/// Gets or sets the reference.
+		/// </summary>
+		/// <value>The reference.</value>
+		public string Reference { get; set; }
+
+		/// <summary>
 		/// Gets or sets the name.
 		/// </summary>
 		/// <value>The name.</value>
@@ -61,6 +79,43 @@ namespace DurianCode.PlacesSearchBar
 		public List<AddressComponent> AddressComponents { get; set; }
 
 		/// <summary>
+		/// Gets or sets the address (formatted)
+		/// </summary>
+		/// <value>The formatted address.</value>
+		public string FormattedAddress { get; set; }
+
+		/// <summary>
+		/// Gets or sets the (international) phone number
+		/// </summary>
+		/// <value>The phone number.</value>
+		public string PhoneNumber { get; set; }
+
+		/// <summary>
+		/// Gets the types of this prediction
+		/// see https://developers.google.com/places/web-service/supported_types
+		/// </summary>
+		/// <value>The types of the prediction.</value>
+		public List<string> Types { get; set; }
+
+		/// <summary>
+		/// Gets or sets the URL.
+		/// </summary>
+		/// <value>The URL.</value>
+		public string Url { get; set; }
+
+		/// <summary>
+		/// Gets or sets the Vicinity.
+		/// </summary>
+		/// <value>The Vicinity.</value>
+		public string Vicinity { get; set; }
+
+		/// <summary>
+		/// Gets or sets the UTC Offset (NULL if not set).
+		/// </summary>
+		/// <value>The UTC Offset.</value>
+		public int? UTCOffset { get; set; }
+
+		/// <summary>
 		/// Gets or sets the raw json value.
 		/// </summary>
 		/// <value>json string.</value>
@@ -72,11 +127,21 @@ namespace DurianCode.PlacesSearchBar
 		/// <param name="jsonObject">Json object.</param>
 		public Place(JObject jsonObject)
 		{
+			ID                = jsonObject["result"]["id"]?.Value<string>() ?? null;
+			Place_ID          = jsonObject["result"]["place_id"].Value<string>();
+			Reference         = jsonObject["result"]["reference"].Value<string>();
 			Name              = jsonObject["result"]["name"].Value<string>();
 			Latitude          = jsonObject["result"]["geometry"]["location"]["lat"].Value<double>();
 			Longitude         = jsonObject["result"]["geometry"]["location"]["lng"].Value<double>();
 			AddressComponents = jsonObject["result"]["address_components"].Value<JArray>().Select(p => AddressComponent.FromJSON(p.Value<JObject>())).ToList();
-			Raw       = jsonObject.ToString();
+			FormattedAddress  = jsonObject["result"]["formatted_address"]?.Value<string>() ?? string.Empty;
+			PhoneNumber       = jsonObject["result"]["international_phone_number"]?.Value<string>() ?? string.Empty;
+			Types             = jsonObject["result"]["types"].Value<JArray>().Select(p => p.Value<string>()).ToList();
+			Url               = jsonObject["result"]["url"]?.Value<string>() ?? string.Empty;
+			Vicinity          = jsonObject["result"]["vicinity"]?.Value<string>() ?? string.Empty;
+			UTCOffset         = jsonObject["result"]["utc_offset"]?.Value<int>();
+
+			Raw               = jsonObject.ToString();
 		}
 
 		public AddressComponent GetAddressComponentOrNull(string type)

--- a/PlacesSearchBar/Place.cs
+++ b/PlacesSearchBar/Place.cs
@@ -64,13 +64,13 @@ namespace DurianCode.PlacesSearchBar
 		/// Gets or sets the latitude.
 		/// </summary>
 		/// <value>The latitude.</value>
-		public double Latitude { get; set; }
+		public double? Latitude { get; set; }
 
 		/// <summary>
 		/// Gets or sets the longitude.
 		/// </summary>
 		/// <value>The longitude.</value>
-		public double Longitude { get; set; }
+		public double? Longitude { get; set; }
 
 		/// <summary>
 		/// Gets or sets the individual address components.
@@ -85,10 +85,16 @@ namespace DurianCode.PlacesSearchBar
 		public string FormattedAddress { get; set; }
 
 		/// <summary>
+		/// Gets or sets the (formatted) phone number
+		/// </summary>
+		/// <value>The phone number.</value>
+		public string PhoneNumberFormatted { get; set; }
+
+		/// <summary>
 		/// Gets or sets the (international) phone number
 		/// </summary>
 		/// <value>The phone number.</value>
-		public string PhoneNumber { get; set; }
+		public string PhoneNumberInternational { get; set; }
 
 		/// <summary>
 		/// Gets the types of this prediction
@@ -98,10 +104,10 @@ namespace DurianCode.PlacesSearchBar
 		public List<string> Types { get; set; }
 
 		/// <summary>
-		/// Gets or sets the URL.
+		/// Gets or sets the Website URL.
 		/// </summary>
-		/// <value>The URL.</value>
-		public string Url { get; set; }
+		/// <value>The Website URL.</value>
+		public string Website { get; set; }
 
 		/// <summary>
 		/// Gets or sets the Vicinity.
@@ -127,21 +133,22 @@ namespace DurianCode.PlacesSearchBar
 		/// <param name="jsonObject">Json object.</param>
 		public Place(JObject jsonObject)
 		{
-			ID                = jsonObject["result"]["id"]?.Value<string>() ?? null;
-			Place_ID          = jsonObject["result"]["place_id"].Value<string>();
-			Reference         = jsonObject["result"]["reference"].Value<string>();
-			Name              = jsonObject["result"]["name"].Value<string>();
-			Latitude          = jsonObject["result"]["geometry"]["location"]["lat"].Value<double>();
-			Longitude         = jsonObject["result"]["geometry"]["location"]["lng"].Value<double>();
-			AddressComponents = jsonObject["result"]["address_components"].Value<JArray>().Select(p => AddressComponent.FromJSON(p.Value<JObject>())).ToList();
-			FormattedAddress  = jsonObject["result"]["formatted_address"]?.Value<string>() ?? string.Empty;
-			PhoneNumber       = jsonObject["result"]["international_phone_number"]?.Value<string>() ?? string.Empty;
-			Types             = jsonObject["result"]["types"].Value<JArray>().Select(p => p.Value<string>()).ToList();
-			Url               = jsonObject["result"]["url"]?.Value<string>() ?? string.Empty;
-			Vicinity          = jsonObject["result"]["vicinity"]?.Value<string>() ?? string.Empty;
-			UTCOffset         = jsonObject["result"]["utc_offset"]?.Value<int>();
+			ID                       = jsonObject["result"]["id"]?.Value<string>();
+			Place_ID                 = jsonObject["result"]["place_id"]?.Value<string>() ?? string.Empty;
+			Reference                = jsonObject["result"]["reference"]?.Value<string>() ?? string.Empty;
+			Name                     = jsonObject["result"]["name"]?.Value<string>() ?? string.Empty;
+			Latitude                 = jsonObject["result"]?["geometry"]?["location"]?["lat"]?.Value<double>();
+			Longitude                = jsonObject["result"]?["geometry"]?["location"]?["lng"]?.Value<double>();
+			AddressComponents        = jsonObject["result"]["address_components"]?.Value<JArray>()?.Select(p => AddressComponent.FromJSON(p.Value<JObject>()))?.ToList() ?? new List<AddressComponent>();
+			FormattedAddress         = jsonObject["result"]["formatted_address"]?.Value<string>() ?? string.Empty;
+			PhoneNumberFormatted     = jsonObject["result"]["formatted_phone_number"]?.Value<string>() ?? string.Empty;
+			PhoneNumberInternational = jsonObject["result"]["international_phone_number"]?.Value<string>() ?? string.Empty;
+			Types                    = jsonObject["result"]["types"]?.Value<JArray>()?.Select(p => p.Value<string>())?.ToList() ?? new List<string>();
+			Website                  = jsonObject["result"]["website"]?.Value<string>() ?? string.Empty;
+			Vicinity                 = jsonObject["result"]["vicinity"]?.Value<string>() ?? string.Empty;
+			UTCOffset                = jsonObject["result"]["utc_offset"]?.Value<int>();
 
-			Raw               = jsonObject.ToString();
+			Raw                      = jsonObject.ToString();
 		}
 
 		public AddressComponent GetAddressComponentOrNull(string type)

--- a/PlacesSearchBar/Places.cs
+++ b/PlacesSearchBar/Places.cs
@@ -81,10 +81,113 @@ namespace DurianCode.PlacesSearchBar
 		/// <returns>The details request URI.</returns>
 		/// <param name="place_id">Place identifier.</param>
 		/// <param name="apiKey">API key.</param>
-		static string CreateDetailsRequestUri(string place_id, string apiKey)
+		private static string CreateDetailsRequestUri(string place_id, string apiKey)
 		{
 			var url = "https://maps.googleapis.com/maps/api/place/details/json";
 			return $"{url}?placeid={Uri.EscapeUriString(place_id)}&key={apiKey}";
+		}
+		
+		/// <summary>
+		/// Calls the Google Places API to retrieve autofill suggestions
+		/// </summary>
+		/// <returns>The places.</returns>
+		/// <param name="newTextValue">New text value.</param>
+		/// <param name="apiKey">The API key</param>
+		/// <param name="bias">The location bias (can be NULL)</param>
+		/// <param name="components">The components (can be NULL)</param>
+		/// <param name="type">Filter for the returning types </param>
+		/// <param name="language">The language of the results</param>
+		public static async Task<AutoCompleteResult> GetPlaces(string newTextValue, string apiKey, LocationBias bias, Components components, PlaceType type, GoogleAPILanguage language)
+		{
+			if (string.IsNullOrEmpty(apiKey))
+			{
+				throw new Exception("You have not assigned a Google API key to PlacesBar");
+			}
+
+			try 
+			{
+				var requestURI = CreatePredictionsUri(newTextValue, apiKey, bias, components, type, language);
+				var client = new HttpClient();
+				var request = new HttpRequestMessage(HttpMethod.Get, requestURI);
+				var response = await client.SendAsync(request);
+
+				if (!response.IsSuccessStatusCode)
+				{
+					Debug.WriteLine("PlacesBar HTTP request denied.");
+					return null;
+				}
+
+				var result = await response.Content.ReadAsStringAsync();
+
+				if (result == "ERROR")
+				{
+					Debug.WriteLine("PlacesSearchBar Google Places API returned ERROR");
+					return null;
+				}
+
+				return AutoCompleteResult.FromJson(JObject.Parse(result));
+			} 
+			catch (Exception ex)
+			{
+				Debug.WriteLine("PlacesBar HTTP issue: {0} {1}", ex.Message, ex);
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Creates the predictions URI.
+		/// </summary>
+		/// <returns>The predictions URI.</returns>
+		/// <param name="newTextValue">New text value.</param>
+		/// <param name="apiKey">The API key</param>
+		/// <param name="bias">The location bias (can be NULL)</param>
+		/// <param name="components">The components (can be NULL)</param>
+		/// <param name="type">Filter for the returning types </param>
+		/// <param name="language">The language of the results</param>
+		private static string CreatePredictionsUri(string newTextValue, string apiKey, LocationBias bias, Components components, PlaceType type, GoogleAPILanguage language)
+		{
+			var url = "https://maps.googleapis.com/maps/api/place/autocomplete/json";
+			var input = Uri.EscapeUriString(newTextValue);
+			var pType = PlaceTypeValue(type);
+
+			var constructedUrl = $"{url}?input={input}&types={pType}&key={apiKey}";
+
+			if (bias != null)
+				constructedUrl = constructedUrl + bias;
+
+			if (components != null)
+				constructedUrl += components;
+
+			if (language != GoogleAPILanguage.Unset) 
+				constructedUrl += "&Language=" + GoogleAPILanguageHelper.ToAPIString(language);
+
+			return constructedUrl;
+		}
+
+		/// <summary>
+		/// Returns a string representation of the specified place type.
+		/// </summary>
+		/// <returns>The type value.</returns>
+		/// <param name="type">Type.</param>
+		private static string PlaceTypeValue(PlaceType type)
+		{
+			switch (type)
+			{
+				case PlaceType.All:
+					return "";
+				case PlaceType.Geocode:
+					return "geocode";
+				case PlaceType.Address:
+					return "address";
+				case PlaceType.Establishment:
+					return "establishment";
+				case PlaceType.Regions:
+					return "(regions)";
+				case PlaceType.Cities:
+					return "(cities)";
+				default:
+					return "";
+			}
 		}
 	}
 }

--- a/PlacesSearchBar/Places.cs
+++ b/PlacesSearchBar/Places.cs
@@ -43,11 +43,14 @@ namespace DurianCode.PlacesSearchBar
 		/// <returns>The place.</returns>
 		/// <param name="placeID">Place identifier.</param>
 		/// <param name="apiKey">API key.</param>
-		public static async Task<Place> GetPlace(string placeID, string apiKey)
+		/// <param name="fields">The fields to query (see https://developers.google.com/places/web-service/details#fields )</param>
+		public static async Task<Place> GetPlace(string placeID, string apiKey, PlacesFieldList fields = null)
 		{
+			fields = fields ?? PlacesFieldList.ALL; // default = ALL fields
+
 			try
 			{
-				var requestURI = CreateDetailsRequestUri(placeID, apiKey);
+				var requestURI = CreateDetailsRequestUri(placeID, apiKey, fields);
 				var client = new HttpClient();
 				var request = new HttpRequestMessage(HttpMethod.Get, requestURI);
 				var response = await client.SendAsync(request);
@@ -81,10 +84,14 @@ namespace DurianCode.PlacesSearchBar
 		/// <returns>The details request URI.</returns>
 		/// <param name="place_id">Place identifier.</param>
 		/// <param name="apiKey">API key.</param>
-		private static string CreateDetailsRequestUri(string place_id, string apiKey)
+		/// <param name="fields">The fields to query (see https://developers.google.com/places/web-service/details#fields )</param>
+		private static string CreateDetailsRequestUri(string place_id, string apiKey, PlacesFieldList fields)
 		{
 			var url = "https://maps.googleapis.com/maps/api/place/details/json";
-			return $"{url}?placeid={Uri.EscapeUriString(place_id)}&key={apiKey}";
+			url += $"?placeid={Uri.EscapeUriString(place_id)}";
+			url += $"&key={apiKey}";
+			if (! fields.IsEmpty()) url += $"&fields={fields}";
+			return url;
 		}
 		
 		/// <summary>

--- a/PlacesSearchBar/PlacesBar.cs
+++ b/PlacesSearchBar/PlacesBar.cs
@@ -29,6 +29,7 @@ using System;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Xamarin.Forms;
 
 namespace DurianCode.PlacesSearchBar
@@ -204,7 +205,7 @@ namespace DurianCode.PlacesSearchBar
 		{
 			if (!string.IsNullOrEmpty(e.NewTextValue) && e.NewTextValue.Length >= MinimumSearchText)
 			{
-				var predictions = await GetPlaces(e.NewTextValue);
+				var predictions = await Places.GetPlaces(e.NewTextValue, ApiKey, Bias, Components, Type, Language);
 				if (PlacesRetrieved != null && predictions != null)
 					OnPlacesRetrieved(predictions);
 				else
@@ -215,97 +216,5 @@ namespace DurianCode.PlacesSearchBar
                 OnPlacesRetrieved(new AutoCompleteResult());
             }
         }
-
-		/// <summary>
-		/// Calls the Google Places API to retrieve autofill suggestions
-		/// </summary>
-		/// <returns>The places.</returns>
-		/// <param name="newTextValue">New text value.</param>
-		async Task<AutoCompleteResult> GetPlaces(string newTextValue)
-		{
-			if (string.IsNullOrEmpty(ApiKey))
-			{
-				throw new Exception(
-					string.Format("You have not assigned a Google API key to PlacesBar"));
-			}
-
-			try 
-			{
-				var requestURI = CreatePredictionsUri(newTextValue);
-				var client = new HttpClient();
-				var request = new HttpRequestMessage(HttpMethod.Get, requestURI);
-				var response = await client.SendAsync(request);
-
-				if (!response.IsSuccessStatusCode)
-				{
-					Debug.WriteLine("PlacesBar HTTP request denied.");
-					return null;
-				}
-
-				var result = await response.Content.ReadAsStringAsync();
-
-				if (result == "ERROR")
-				{
-					Debug.WriteLine("PlacesSearchBar Google Places API returned ERROR");
-					return null;
-				}
-
-				return JsonConvert.DeserializeObject<AutoCompleteResult>(result);
-			} 
-			catch (Exception ex)
-			{
-				Debug.WriteLine("PlacesBar HTTP issue: {0} {1}", ex.Message, ex);
-				return null;
-			}
-		}
-
-		/// <summary>
-		/// Creates the predictions URI.
-		/// </summary>
-		/// <returns>The predictions URI.</returns>
-		/// <param name="newTextValue">New text value.</param>
-		string CreatePredictionsUri(string newTextValue)
-		{
-			var url = "https://maps.googleapis.com/maps/api/place/autocomplete/json";
-			var input = Uri.EscapeUriString(newTextValue);
-			var pType = PlaceTypeValue(Type);
-			var constructedUrl = $"{url}?input={input}&types={pType}&key={ApiKey}";
-
-			if (Bias != null)
-				constructedUrl = constructedUrl + Bias;
-            if (Components != null)
-                constructedUrl += Components;
-
-			if (Language != GoogleAPILanguage.Unset) constructedUrl += "&Language=" + GoogleAPILanguageHelper.ToAPIString(Language);
-
-			return constructedUrl;
-		}
-
-		/// <summary>
-		/// Returns a string representation of the specified place type.
-		/// </summary>
-		/// <returns>The type value.</returns>
-		/// <param name="type">Type.</param>
-		string PlaceTypeValue(PlaceType type)
-		{
-			switch (type)
-			{
-				case PlaceType.All:
-					return "";
-				case PlaceType.Geocode:
-					return "geocode";
-				case PlaceType.Address:
-					return "address";
-				case PlaceType.Establishment:
-					return "establishment";
-				case PlaceType.Regions:
-					return "(regions)";
-				case PlaceType.Cities:
-					return "(cities)";
-				default:
-					return "";
-			}
-		}
-
 	}
 }

--- a/PlacesSearchBar/PlacesBar.cs
+++ b/PlacesSearchBar/PlacesBar.cs
@@ -67,6 +67,11 @@ namespace DurianCode.PlacesSearchBar
         /// Backing store for the MinimumSearchText property.
         /// </summary>
         public static readonly BindableProperty MinimumSearchTextProperty = BindableProperty.Create(nameof(MinimumSearchText), typeof(int), typeof(PlacesBar), 2, BindingMode.OneWay, (BindableProperty.ValidateValueDelegate)null, (BindableProperty.BindingPropertyChangedDelegate)null, (BindableProperty.BindingPropertyChangingDelegate)null, (BindableProperty.CoerceValueDelegate)null, (BindableProperty.CreateDefaultValueDelegate)null);
+		
+        /// <summary>
+        /// Backing store for the MinimumSearchText property.
+        /// </summary>
+        public static readonly BindableProperty LanguageProperty = BindableProperty.Create(nameof(Language), typeof(GoogleAPILanguage), typeof(PlacesBar), GoogleAPILanguage.Unset, BindingMode.OneWay, (BindableProperty.ValidateValueDelegate)null, (BindableProperty.BindingPropertyChangedDelegate)null, (BindableProperty.BindingPropertyChangingDelegate)null, (BindableProperty.CoerceValueDelegate)null, (BindableProperty.CreateDefaultValueDelegate)null);
 
         #region Property accessors
         /// <summary>
@@ -149,6 +154,26 @@ namespace DurianCode.PlacesSearchBar
                 this.SetValue(PlacesBar.MinimumSearchTextProperty, (object)value);
             }
         }
+
+		/// <summary>
+		/// Gets or sets the language for the API call.
+		/// The language code, indicating in which language the results should be returned, if possible.
+		/// Searches are also biased to the selected language; results in the selected language may be given a higher ranking
+		/// </summary>
+		/// <value>The languagey.</value>
+		public GoogleAPILanguage Language
+		{
+			get
+			{
+				return (GoogleAPILanguage)this.GetValue(PlacesBar.LanguageProperty);
+
+			}
+			set
+			{
+				this.SetValue(PlacesBar.LanguageProperty, (object)value);
+			}
+		}
+
 		#endregion
 
 		/// <summary>
@@ -250,6 +275,8 @@ namespace DurianCode.PlacesSearchBar
 				constructedUrl = constructedUrl + Bias;
             if (Components != null)
                 constructedUrl += Components;
+
+			if (Language != GoogleAPILanguage.Unset) constructedUrl += "&Language=" + GoogleAPILanguageHelper.ToAPIString(Language);
 
 			return constructedUrl;
 		}

--- a/PlacesSearchBar/PlacesField.cs
+++ b/PlacesSearchBar/PlacesField.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DurianCode.PlacesSearchBar
+{
+	public enum PlacesField
+	{
+		// [Basic] fields
+
+		AddressComponents,
+		Address,
+		AlternativeID,
+		FormattedAddress,
+		Location,
+		Viewport,
+		Icon,
+		ID,
+		Name,
+		PermanentlyClosed,
+		Photo,
+		PlaceID,
+		PlusCode,
+		Scope,
+		Type,
+		URL,
+		UTCOffset,
+		Vicinity,
+		
+		// [Contact] fields
+
+		PhoneNumber,
+		InternationalPhoneNumber,
+		OpeningHours,
+		Website,
+		
+		// [Atmosphere] fields
+
+		PriceLevel,
+		Rating,
+		Reviews,
+		UserRatingsTotal,
+
+	}
+
+	public class PlacesFieldList
+	{
+		public static readonly PlacesFieldList ALL     = new PlacesFieldList();
+
+		public static readonly PlacesFieldList DEFAULT = new PlacesFieldList(
+			PlacesField.AddressComponents, 
+			PlacesField.FormattedAddress, 
+			PlacesField.Location,
+			PlacesField.ID,
+			PlacesField.Name,
+			PlacesField.PlaceID);
+
+		public readonly IReadOnlyList<PlacesField> Fields;
+		
+		public PlacesFieldList(params PlacesField[] fields)
+		{
+			Fields = fields.ToList().AsReadOnly();
+		}
+
+		public string ToString(PlacesField field)
+		{
+			switch (field)
+			{
+				case PlacesField.AddressComponents:        return "address_component";
+				case PlacesField.Address:                  return "adr_address";
+				case PlacesField.AlternativeID:            return "alt_id";
+				case PlacesField.FormattedAddress:         return "formatted_address";
+				case PlacesField.Location:                 return "geometry/location";
+				case PlacesField.Viewport:                 return "geometry/viewport";
+				case PlacesField.Icon:                     return "icon";
+				case PlacesField.ID:                       return "id";
+				case PlacesField.Name:                     return "name";
+				case PlacesField.PermanentlyClosed:        return "permanently_closed";
+				case PlacesField.Photo:                    return "photo";
+				case PlacesField.PlaceID:                  return "place_id";
+				case PlacesField.PlusCode:                 return "plus_code";
+				case PlacesField.Scope:                    return "scope";
+				case PlacesField.Type:                     return "type";
+				case PlacesField.URL:                      return "url";
+				case PlacesField.UTCOffset:                return "utc_offset";
+				case PlacesField.Vicinity:                 return "vicinity";
+				case PlacesField.PhoneNumber:              return "formatted_phone_number";
+				case PlacesField.InternationalPhoneNumber: return "international_phone_number";
+				case PlacesField.OpeningHours:             return "opening_hours";
+				case PlacesField.Website:                  return "website";
+				case PlacesField.PriceLevel:               return "price_level";
+				case PlacesField.Rating:                   return "rating";
+				case PlacesField.Reviews:                  return "review";
+				case PlacesField.UserRatingsTotal:         return "user_ratings_total";
+			}
+
+			throw new ArgumentException("Invalid PlacesField");
+		}
+
+		public bool IsEmpty()
+		{
+			return Fields.Any();
+		}
+
+		public override string ToString()
+		{
+			return string.Join(",", Fields.Select(ToString));
+		}
+	}
+}

--- a/PlacesSearchBar/PlacesSearchBar.csproj
+++ b/PlacesSearchBar/PlacesSearchBar.csproj
@@ -32,6 +32,6 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.561731" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I started using this library in a xamarin project I'm doing and I started missing some stuff - so I implemented it...

 - Added a language field to the SearchBar, setting the language results in localized results and better ordering of the predictions ( https://developers.google.com/places/web-service/autocomplete )
 - Added `MainText` and `SecondaryText` fields to AutoCompletePrediction. These fields are normally used to display a prediction (I also updated the example project)
 - Added fields `terms` and `types` to the AutoCompletePrediction class. Personally I don't need them but now all json fields are accessible in the class.
 - Added `AddressComponents` field to the Place class. Together with a few convenience Properties this allows us to access fields as `StreetName`, `Country`, `PostalCode`, ...
 - Added (most) other missing fields in the Place class (values that are in the json response but where not read)
 - Added an (optional) fields parameter to GetPlace() to limit the queries fields. If the fields are not limited all fields are queried and also billed... The default value is still "query-everything"

In the next few weeks I have to add location-search to a few places in our app. Eventually I'll make some more pull requests. But for now this one adds a bit of feature-parity with the android library :D

----

PS: All changes should be backwards compatible and updating the code should'nt be a problem **except** at one point:  
The Latitude and Longitude properties in the Places class are now `double?` (they were only `double` before), because you can make a getPlace() request without PlaceField.Location.